### PR TITLE
Rename image-update -> image-reflector-controller

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,5 +1,5 @@
 domain: fluxcd.io
-repo: github.com/squaremo/image-update
+repo: github.com/squaremo/image-reflector-controller
 resources:
 - group: image
   kind: ImageRepository

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Image update controller
+# Image (metadata) refector controller
 
 This is an attempt to build controllers along the lines set out in
 https://squaremo.dev/posts/gitops-controllers/.
+
+This repository implements the image metadata reflector controller,
+which scans container image repositories and reflects the metadata, in
+Kubernetes resources. The sibling repository
+[image-automation-controller](https://github.com/squaremo/image-automation-controller)
+implements the automation controller, which acts on the reflected data
+(e.g., a new image version) by updating the image references used in
+files in git.

--- a/controllers/imagepolicy_controller.go
+++ b/controllers/imagepolicy_controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	imagev1alpha1 "github.com/squaremo/image-update/api/v1alpha1"
+	imagev1alpha1 "github.com/squaremo/image-reflector-controller/api/v1alpha1"
 )
 
 // this is used as the key for the index of policy->repository; the

--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -28,7 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	imagev1alpha1 "github.com/squaremo/image-update/api/v1alpha1"
+	imagev1alpha1 "github.com/squaremo/image-reflector-controller/api/v1alpha1"
 )
 
 const (

--- a/controllers/policy_test.go
+++ b/controllers/policy_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	imagev1alpha1 "github.com/squaremo/image-update/api/v1alpha1"
+	imagev1alpha1 "github.com/squaremo/image-reflector-controller/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/controllers/scan_test.go
+++ b/controllers/scan_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 
-	imagev1alpha1 "github.com/squaremo/image-update/api/v1alpha1"
+	imagev1alpha1 "github.com/squaremo/image-reflector-controller/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,7 +37,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	imagev1alpha1 "github.com/squaremo/image-update/api/v1alpha1"
+	imagev1alpha1 "github.com/squaremo/image-reflector-controller/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/squaremo/image-update
+module github.com/squaremo/image-reflector-controller
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	imagev1alpha1 "github.com/squaremo/image-update/api/v1alpha1"
-	"github.com/squaremo/image-update/controllers"
+	imagev1alpha1 "github.com/squaremo/image-reflector-controller/api/v1alpha1"
+	"github.com/squaremo/image-reflector-controller/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
To keep the pieces of the design separate, it's convenient for the automation controller to have its own repository. That means this repository will deal only with the reflection of image metadata into the cluster; and, the longer name seems more the gitops toolkit way.