### PR TITLE
Standardise namespace used in config

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,5 @@
 # Adds namespace to all resources.
-namespace: image-update-system
-
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: image-update-
+namespace: image-reflector-system
 
 # Labels to add to all resources and selectors.
 #commonLabels:
@@ -16,6 +9,10 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+
+resources:
+- namespace.yaml
+
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: image-reflector-controller
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: image-reflector-controller
   namespace: system
 spec:
   template:

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: image-reflector-system
+  labels:
+    control-plane: controller


### PR DESCRIPTION
 - add a namespace resource at the top (used to be in manager/)
 - replace original namespace `image-update-system` with
   `image-reflector-system`
 - don't rely on a name prefix; it's unnecessary and confusing