### PR TITLE
Make patches work with kustomize build

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,10 +1,10 @@
-# This patch inject a sidecar container which is a HTTP proxy for the 
-# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the
+# Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: image-reflector-controller
-  namespace: system
 spec:
   template:
     spec:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: image-reflector-controller
-  namespace: system
 spec:
   template:
     spec:


### PR DESCRIPTION
In the most recent kustomize version, the patches in config/default/
fail to apply. (`kubectl apply -k` does not use the most kustomize
version, and seems to cope fine.)