### PR TITLE
Follow up to changing the default branch to 'main'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   test:
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: 1.14.x
     - name: Set up kubebuilder
-      uses: fluxcd/pkg/actions/kubebuilder@master
+      uses: fluxcd/pkg/actions/kubebuilder@v0.0.4
     - name: Run tests
       run: make test
       env:


### PR DESCRIPTION
 - [x] change trigger in github actions workflow to 'main'
 - [x]  give the action from fluxcd/pkg a version, rather than getting it from a branch at all.
 - [x] examine code for hard-coded default branch

(on that last: grep turns up no hard-coded branch name; not too surprising as this controller doesn't deal with git)